### PR TITLE
Update TimeAPI.ts

### DIFF
--- a/src/time/TimeAPI.ts
+++ b/src/time/TimeAPI.ts
@@ -33,8 +33,9 @@ export class TimeAPI {
    * Get the absolute difference between server time and local time.
    */
   async getClockSkew(): Promise<number> {
-    const {epoch} = await this.getTime();
+    const time = await this.getTime();
     const now = Date.now() / 1000;
-    return parseFloat(`${epoch}`) - now;
+    if(typeof(time)==="string") { var epoch = parseFloat(time.match(/epoch":(.*)\./i)[1]); } else { var {epoch}=time };            
+    return epoch - now;
   }
 }


### PR DESCRIPTION
Return ClockSkew  in situations where epoch has no milliseconds and getTime() returns a string instead of an object