### PR TITLE
Update README to link to coinbase-pro-node deprecation comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Motivation
 
-The purpose of [coinbase-pro-node][5] is to continue an active **Coinbase Pro API** after Coinbase deprecated the official Node.js library on [January, 16 2020](https://github.com/coinbase/coinbase-node/issues/140#issuecomment-574990136). Its predecessor got deprecated on [July, 19th 2016](https://github.com/coinbase/coinbase-exchange-node/commit/b8347efdb4e2589367c1395b646d283c9c391681).
+The purpose of [coinbase-pro-node][5] is to continue an active **Coinbase Pro API** after Coinbase deprecated the official Node.js library on [January, 16 2020](https://github.com/coinbase/coinbase-pro-node/issues/393#issuecomment-574993096). Its predecessor got deprecated on [July, 19th 2016](https://github.com/coinbase/coinbase-exchange-node/commit/b8347efdb4e2589367c1395b646d283c9c391681).
 
 ## Features
 


### PR DESCRIPTION
This seems like a pedantic change, but when I first found this package I had to do some hunting to check if the official `coinbase-pro-node` package had been deprecated, or only `coinbase-node`.
The README currently links to a comment on a PR for `coinbase-node` - the package for the "normal" Coinbase API. But this package is for Coinbase Pro (formerly Gdax) so that's not relevant. I saw on the coinbase-pro-node repo all those PRs are also closed for the same reason: https://github.com/coinbase/coinbase-pro-node/issues?q=is%3Aissue+is%3Aclosed
So I've just updated the README here to reference the coinbase-pro-node package instead of coinbase-node.