### PR TITLE
Support for transfers between portfolios by type.

### DIFF
--- a/src/transfer/TransferAPI.ts
+++ b/src/transfer/TransferAPI.ts
@@ -29,6 +29,8 @@ export interface TransferInformation {
 export enum TransferType {
   DEPOSIT = 'deposit',
   WITHDRAW = 'withdraw',
+  INTERNAL_DEPOSIT = 'internal_deposit',
+  INTERNAL_WITHDRAW = 'internal_withdraw',
 }
 
 export class TransferAPI {


### PR DESCRIPTION
'TransferAPI.getTransfers' currently cannot retrieve internal transfers from the API due to be restricted to only external transfers. Adding "internal_" prefix queues the API to get the requested information.

You can see the support for this type/string in the documentation:
Deposits: https://docs.pro.coinbase.com/#list-deposits
Withdrawls: https://docs.pro.coinbase.com/#list-withdrawals