### PR TITLE
Fix for 'ProductAPI.getProduct' on sandbox.

### DIFF
--- a/src/product/ProductAPI.test.ts
+++ b/src/product/ProductAPI.test.ts
@@ -41,7 +41,7 @@ describe('ProductAPI', () => {
         );
 
       const product = await global.client.rest.product.getProduct(productId);
-      expect(product!.display_name).toBe('BTC/USD');
+      expect(product!.display_name).toBe('BTC/EUR');
     });
   });
 

--- a/src/product/ProductAPI.test.ts
+++ b/src/product/ProductAPI.test.ts
@@ -21,23 +21,23 @@ describe('ProductAPI', () => {
         .reply(
           200,
           JSON.stringify({
-              base_currency: 'BTC',
-              base_increment: '0.00000001',
-              base_max_size: '200',
-              base_min_size: '0.001',
-              cancel_only: false,
-              display_name: 'BTC/EUR',
-              id: 'BTC-EUR',
-              limit_only: false,
-              margin_enabled: false,
-              max_market_funds: '600000',
-              min_market_funds: '10',
-              post_only: false,
-              quote_currency: 'EUR',
-              quote_increment: '0.01',
-              status: 'online',
-              status_message: '',
-            })
+            base_currency: 'BTC',
+            base_increment: '0.00000001',
+            base_max_size: '200',
+            base_min_size: '0.001',
+            cancel_only: false,
+            display_name: 'BTC/EUR',
+            id: 'BTC-EUR',
+            limit_only: false,
+            margin_enabled: false,
+            max_market_funds: '600000',
+            min_market_funds: '10',
+            post_only: false,
+            quote_currency: 'EUR',
+            quote_increment: '0.01',
+            status: 'online',
+            status_message: '',
+          })
         );
 
       const product = await global.client.rest.product.getProduct(productId);

--- a/src/product/ProductAPI.test.ts
+++ b/src/product/ProductAPI.test.ts
@@ -14,13 +14,13 @@ describe('ProductAPI', () => {
 
   describe('getProduct', () => {
     it('returns trading details for a specified product', async () => {
+      const productId = 'BTC-EUR';
       nock(global.REST_URL)
-        .get(ProductAPI.URL.PRODUCTS)
+        .get(`${ProductAPI.URL.PRODUCTS}/${productId}`)
         .query(true)
         .reply(
           200,
-          JSON.stringify([
-            {
+          JSON.stringify({
               base_currency: 'BTC',
               base_increment: '0.00000001',
               base_max_size: '200',
@@ -37,30 +37,11 @@ describe('ProductAPI', () => {
               quote_increment: '0.01',
               status: 'online',
               status_message: '',
-            },
-            {
-              base_currency: 'XRP',
-              base_increment: '1',
-              base_max_size: '500000',
-              base_min_size: '1',
-              cancel_only: false,
-              display_name: 'XRP/USD',
-              id: 'XRP-USD',
-              limit_only: false,
-              margin_enabled: false,
-              max_market_funds: '100000',
-              min_market_funds: '10',
-              post_only: false,
-              quote_currency: 'USD',
-              quote_increment: '0.0001',
-              status: 'online',
-              status_message: '',
-            },
-          ])
+            })
         );
 
-      const product = await global.client.rest.product.getProduct('XRP-USD');
-      expect(product!.display_name).toBe('XRP/USD');
+      const product = await global.client.rest.product.getProduct(productId);
+      expect(product!.display_name).toBe('BTC/USD');
     });
   });
 

--- a/src/product/ProductAPI.test.ts
+++ b/src/product/ProductAPI.test.ts
@@ -21,23 +21,23 @@ describe('ProductAPI', () => {
         .reply(
           200,
           JSON.stringify({
-            base_currency: 'BTC',
-            base_increment: '0.00000001',
-            base_max_size: '200',
-            base_min_size: '0.001',
-            cancel_only: false,
-            display_name: 'BTC/EUR',
-            id: 'BTC-EUR',
-            limit_only: false,
-            margin_enabled: false,
-            max_market_funds: '600000',
-            min_market_funds: '10',
-            post_only: false,
-            quote_currency: 'EUR',
-            quote_increment: '0.01',
-            status: 'online',
-            status_message: '',
-          })
+              base_currency: 'BTC',
+              base_increment: '0.00000001',
+              base_max_size: '200',
+              base_min_size: '0.001',
+              cancel_only: false,
+              display_name: 'BTC/EUR',
+              id: 'BTC-EUR',
+              limit_only: false,
+              margin_enabled: false,
+              max_market_funds: '600000',
+              min_market_funds: '10',
+              post_only: false,
+              quote_currency: 'EUR',
+              quote_increment: '0.01',
+              status: 'online',
+              status_message: '',
+            })
         );
 
       const product = await global.client.rest.product.getProduct(productId);

--- a/src/product/ProductAPI.ts
+++ b/src/product/ProductAPI.ts
@@ -284,8 +284,9 @@ export class ProductAPI {
    * @see https://docs.pro.coinbase.com/#get-products
    */
   async getProduct(productId: string): Promise<Product | undefined> {
-    const products = await this.getProducts();
-    return products.find(product => product.id === productId);
+    const resource = `${ProductAPI.URL.PRODUCTS}/${productId}`;
+    const response = await this.apiClient.get<Product[]>(resource);
+    return response.data;
   }
 
   /**

--- a/src/product/ProductAPI.ts
+++ b/src/product/ProductAPI.ts
@@ -285,7 +285,7 @@ export class ProductAPI {
    */
   async getProduct(productId: string): Promise<Product | undefined> {
     const resource = `${ProductAPI.URL.PRODUCTS}/${productId}`;
-    const response = await this.apiClient.get<Product[]>(resource);
+    const response = await this.apiClient.get<Product>(resource);
     return response.data;
   }
 


### PR DESCRIPTION
On sandbox, it appears that the '/products' endpoint rotates values. If you try to get 'BTC-USD' while it is out of the rotation, it will not return a product because 'find' will return void. However, getting the '/products/productId' endpoint directly retrieves the requested data regardless if it exists inside the '/products' endpoint at that time.

This can be tested by refreshing the public endpoint directly to witness the rotation of products.  They cycle about 5-15second intervals.
Sandbox Products: https://api-public.sandbox.pro.coinbase.com/products
Sandbox BTC-USD (example): https://api-public.sandbox.pro.coinbase.com/products/BTC-USD
Sandbox BTC-EUR (example): https://api-public.sandbox.pro.coinbase.com/products/BTC-EUR