### PR TITLE
Make the ReconnectingSocket object accessible outside of WebSocketClient

### DIFF
--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -235,7 +235,7 @@ export class WebSocketClient extends EventEmitter {
   };
 
   private readonly baseURL: string;
-  public readonly socket: ReconnectingWebSocket | undefined;
+  public socket: ReconnectingWebSocket | undefined;
 
   private pingInterval?: NodeJS.Timeout;
   private pongTimeout?: NodeJS.Timeout;

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -235,7 +235,7 @@ export class WebSocketClient extends EventEmitter {
   };
 
   private readonly baseURL: string;
-  private socket: ReconnectingWebSocket | undefined;
+  public socket: ReconnectingWebSocket | undefined;
 
   private pingInterval?: NodeJS.Timeout;
   private pongTimeout?: NodeJS.Timeout;

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -235,7 +235,7 @@ export class WebSocketClient extends EventEmitter {
   };
 
   private readonly baseURL: string;
-  public socket: ReconnectingWebSocket | undefined;
+  public readonly socket: ReconnectingWebSocket | undefined;
 
   private pingInterval?: NodeJS.Timeout;
   private pongTimeout?: NodeJS.Timeout;


### PR DESCRIPTION
Sometimes it may be necessary to access this object to make changes, or more likely just to determine its current status.