### PR TITLE
Improve account history detail type

### DIFF
--- a/src/account/AccountAPI.ts
+++ b/src/account/AccountAPI.ts
@@ -19,10 +19,17 @@ export interface AccountHistory {
   type: string;
 }
 
-export interface AccountHistoryDetails {
+type AccountHistoryDetails = AccountHistoryTradeDetail & AccountHistoryTransferDetail;
+
+export interface AccountHistoryTradeDetail {
   order_id: string;
   product_id: string;
   trade_id: string;
+}
+
+export interface AccountHistoryTransferDetail {
+  transfer_id: string;
+  transfer_type: string;
 }
 
 export interface Hold {


### PR DESCRIPTION
The account history records with the type `transfer` has its `details` field with the 2 properties `tranfer_id` and `transfer_type`.  This PR improves the `AccountHistoryDetails` type to support this transfer type as well.