### PR TITLE
Add ticker_1000 ws channel

### DIFF
--- a/src/client/WebSocketClient.test.ts
+++ b/src/client/WebSocketClient.test.ts
@@ -205,6 +205,22 @@ describe('WebSocketClient', () => {
       ws.connect();
     });
 
+    it('receives typed "ticker" messages from the special "ticker_1000" channel', done => {
+      const channel = {
+        name: WebSocketChannelName.TICKER_1000,
+        product_ids: ['BTC-USD'],
+      };
+
+      const ws = mockWebSocketResponse(done, channel, tickerBTCUSD);
+
+      ws.on(WebSocketEvent.ON_MESSAGE_TICKER, tickerMessage => {
+        expect(tickerMessage.trade_id).toBe(3526965);
+        ws.unsubscribe(channel);
+      });
+
+      ws.connect();
+    });
+
     it('receives typed messages from multiple "matches" channels', done => {
       const channels = [
         {

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -22,6 +22,8 @@ export enum WebSocketChannelName {
   STATUS = 'status',
   /** The ticker channel provides real-time price updates every time a match happens. It batches updates in case of cascading matches, greatly reducing bandwidth requirements. */
   TICKER = 'ticker',
+  /** A special version of the ticker channel that only provides a ticker update about every 5 seconds. */
+  TICKER_1000 = 'ticker_1000',
   /** This channel is a version of the full channel that only contains messages that include the authenticated user. Consequently, you need to be authenticated to receive any messages. */
   USER = 'user',
 }


### PR DESCRIPTION
Coinbase Pro uses a special version of the ticker channel named 'ticker_1000' which only provides a ticker message about every 5 seconds instead of as each tick happens. This can lighten the load on the client if it doesn't need every single ticker message. In this commit I'm adding that channel name.