### PR TITLE
Add WebSocket connected() function

### DIFF
--- a/src/client/WebSocketClient.test.ts
+++ b/src/client/WebSocketClient.test.ts
@@ -77,6 +77,44 @@ describe('WebSocketClient', () => {
     });
   });
 
+  describe('connected', () => {
+    it('returns false when called before the connection is created', done => {
+      const ws = createWebSocketClient();
+      expect(ws.connected).toBe(false);
+      done();
+    });
+    it('returns true when called after the connection is created', done => {
+      const ws = createWebSocketClient();
+
+      ws.on(WebSocketEvent.ON_CLOSE, () => {
+        done();
+      });
+
+      ws.on(WebSocketEvent.ON_OPEN, () => {
+        expect(ws.connected).toBe(true);
+
+        ws.disconnect();
+      });
+
+      ws.connect();
+    });
+
+    it('returns false when called after the connection is closed', done => {
+      const ws = createWebSocketClient();
+
+      ws.on(WebSocketEvent.ON_CLOSE, () => {
+        expect(ws.connected).toBe(false);
+        done();
+      });
+
+      ws.on(WebSocketEvent.ON_OPEN, () => {
+        ws.disconnect();
+      });
+
+      ws.connect();
+    });
+  });
+
   describe('constructor', () => {
     it('it signals an event when the WebSocket connection is established', done => {
       const ws = createWebSocketClient();

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -331,6 +331,15 @@ export class WebSocketClient extends EventEmitter {
     }
   }
 
+  /**
+   * A simple function to determine if the websocket appears to be open.
+   *
+   * @returns True if the websocket has been opened and has not closed.
+   */
+  get connected(): boolean {
+    return undefined !== this.socket;
+  }
+
   async sendMessage(message: WebSocketRequest): Promise<void> {
     if (!this.socket) {
       throw new Error(`Failed to send message of type "${message.type}": You need to connect to the WebSocket first.`);


### PR DESCRIPTION
This is a helper function for determining if the underlying WebSocket has not yet closed. Needing to know this was the main reason I requested #608 to make the socket public. If you think it'd be okay, we could probably revert that change with this. The issue is that some people may be relying on the socket being public now.

Also, I wasn't sure what your preference would be a `connected()` function or a getter property. I can change if you prefer that.