### PR TITLE
Add WebSocket channel auto-resubscription

### DIFF
--- a/src/client/WebSocketClient.test.ts
+++ b/src/client/WebSocketClient.test.ts
@@ -304,8 +304,8 @@ describe('WebSocketClient', () => {
 
       if (channels && options?.subscribeOnOpen) {
         // Send subscription once the WebSocket is ready
-        ws.on(WebSocketEvent.ON_OPEN, () => {
-          ws.subscribe(channels);
+        ws.on(WebSocketEvent.ON_OPEN, async () => {
+          await ws.subscribe(channels);
         });
       }
 
@@ -589,8 +589,8 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
 
         const subs = ws.subscriptions;
 
@@ -615,9 +615,9 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
-        ws.subscribe(channel2);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
+        await ws.subscribe(channel2);
 
         const subs = ws.subscriptions;
 
@@ -645,10 +645,10 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe([channel, channel2]);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe([channel, channel2]);
 
-        ws.unsubscribe({
+        await ws.unsubscribe({
           name: WebSocketChannelName.TICKER,
           product_ids: ['ETH-USD'],
         });
@@ -675,8 +675,8 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe([channel, channel2]);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe([channel, channel2]);
 
         expect(ws.subscriptions).toEqual([channel2, channel]);
       });
@@ -697,10 +697,10 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe([channel, channel2]);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe([channel, channel2]);
 
-        ws.unsubscribe({
+        await ws.unsubscribe({
           name: WebSocketChannelName.TICKER,
           product_ids: ['BTC-USD'],
         });
@@ -724,10 +724,10 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe([channel, channel2]);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe([channel, channel2]);
 
-        ws.unsubscribe(WebSocketChannelName.TICKER);
+        await ws.unsubscribe(WebSocketChannelName.TICKER);
 
         expect(ws.subscriptions).toEqual([channel2]);
       });
@@ -750,10 +750,10 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {doneOnClose: false});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
         if (!isReconnect) {
-          ws.subscribe(channel2);
-          ws.subscribe(channel);
+          await ws.subscribe(channel2);
+          await ws.subscribe(channel);
 
           isReconnect = true;
 
@@ -791,8 +791,8 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done);
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
       });
 
       ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, () => {
@@ -812,8 +812,8 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {doneOnClose: false});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
       });
 
       ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, () => {
@@ -837,10 +837,10 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
 
-        ws.unsubscribe({name: WebSocketChannelName.TICKER});
+        await ws.unsubscribe({name: WebSocketChannelName.TICKER});
 
         expect(ws.subscriptions).toEqual([]);
       });
@@ -856,8 +856,8 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done, undefined, undefined, {disconnectOnSubscriptionResponse: true});
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
       });
 
       ws.connect();
@@ -873,8 +873,8 @@ describe('WebSocketClient', () => {
 
       const ws = mockWebSocketClientSubscription(done);
 
-      ws.on(WebSocketEvent.ON_OPEN, () => {
-        ws.subscribe(channel);
+      ws.on(WebSocketEvent.ON_OPEN, async () => {
+        await ws.subscribe(channel);
 
         expect(ws.subscriptions).toEqual([channel]);
         expect(ws.willAutoResubscribe).toBe(false);
@@ -908,9 +908,9 @@ describe('WebSocketClient', () => {
 
       const ws = createWebSocketClient();
 
-      ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, async subscriptions => {
+      ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, subscriptions => {
         if (subscriptions.channels.length === 0) {
-          await ws.disconnect();
+          ws.disconnect();
         }
       });
 

--- a/src/client/WebSocketClient.test.ts
+++ b/src/client/WebSocketClient.test.ts
@@ -160,6 +160,22 @@ describe('WebSocketClient', () => {
 
       ws.connect();
     });
+
+    it('sets the disconnect reason in the options object', done => {
+      const ws = createWebSocketClient();
+
+      ws.on(WebSocketEvent.ON_OPEN, () => {
+        ws.disconnect({reason: 'We received the subscription!'});
+      });
+
+      ws.on(WebSocketEvent.ON_CLOSE, e => {
+        expect(e.reason).toBe('We received the subscription!');
+
+        done();
+      });
+
+      ws.connect();
+    });
   });
 
   describe('sendMessage', () => {
@@ -799,31 +815,6 @@ describe('WebSocketClient', () => {
         ws.disconnect({forgetSubscriptions: true});
 
         expect(ws.subscriptions).toEqual([]);
-      });
-
-      ws.connect();
-    });
-
-    it('sets the disconnect reason in the options object', done => {
-      const channel: WebSocketChannel = {
-        name: WebSocketChannelName.TICKER,
-        product_ids: ['BTC-USD', 'ETH-USD'],
-      };
-
-      const ws = mockWebSocketClientSubscription(done, undefined, undefined, {doneOnClose: false});
-
-      ws.on(WebSocketEvent.ON_OPEN, async () => {
-        await ws.subscribe(channel);
-      });
-
-      ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, () => {
-        ws.disconnect({reason: 'We received the subscription!'});
-      });
-
-      ws.on(WebSocketEvent.ON_CLOSE, e => {
-        expect(e.reason).toBe('We received the subscription!');
-
-        done();
       });
 
       ws.connect();

--- a/src/client/WebSocketClient.test.ts
+++ b/src/client/WebSocketClient.test.ts
@@ -796,9 +796,34 @@ describe('WebSocketClient', () => {
       });
 
       ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, () => {
-        ws.disconnect(undefined, true);
+        ws.disconnect({forgetSubscriptions: true});
 
         expect(ws.subscriptions).toEqual([]);
+      });
+
+      ws.connect();
+    });
+
+    it('sets the disconnect reason in the options object', done => {
+      const channel: WebSocketChannel = {
+        name: WebSocketChannelName.TICKER,
+        product_ids: ['BTC-USD', 'ETH-USD'],
+      };
+
+      const ws = mockWebSocketClientSubscription(done, undefined, undefined, {doneOnClose: false});
+
+      ws.on(WebSocketEvent.ON_OPEN, () => {
+        ws.subscribe(channel);
+      });
+
+      ws.on(WebSocketEvent.ON_SUBSCRIPTION_UPDATE, () => {
+        ws.disconnect({reason: 'We received the subscription!'});
+      });
+
+      ws.on(WebSocketEvent.ON_CLOSE, e => {
+        expect(e.reason).toBe('We received the subscription!');
+
+        done();
       });
 
       ws.connect();

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -570,9 +570,10 @@ export class WebSocketClient extends EventEmitter {
         if (this._subscriptions[chan.name]) {
           if (undefined !== chan.product_ids) {
             // Remove product ids from the channel
-            this._subscriptions[chan.name].product_ids = this._subscriptions[chan.name].product_ids.filter(
-              x => !chan.product_ids?.includes(x)
-            );
+            this._subscriptions[chan.name].product_ids = this._subscriptions[chan.name].product_ids.filter(x => {
+              /* istanbul ignore next: there should always be product_ids based on above typeguard */
+              return !chan.product_ids?.includes(x);
+            });
 
             // If no more products subscribed on the channel, delete its reference
             if (0 === this._subscriptions[chan.name].product_ids.length) {
@@ -606,6 +607,7 @@ export class WebSocketClient extends EventEmitter {
   private generateSubscriptionsCache(): void {
     const channels: WebSocketChannel[] = [];
     for (const channelName in this._subscriptions) {
+      /* istanbul ignore else: see https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md#ignore-an-else-path */
       if (Object.prototype.hasOwnProperty.call(this._subscriptions, channelName)) {
         const chan = this._subscriptions[channelName];
 

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -126,6 +126,11 @@ type ReconnectOptions = Options & {
   autoResubscribe?: boolean;
 };
 
+type DisconnectOptions = {
+  forgetSubscriptions?: boolean;
+  reason?: string;
+};
+
 export type WebSocketResponse = WebSocketMessage & {type: WebSocketResponseType};
 
 // Not exported because it will become "WebSocketResponse" once complete
@@ -494,7 +499,21 @@ export class WebSocketClient extends EventEmitter {
     return this.socket;
   }
 
-  disconnect(reason: string = 'Unknown reason', forgetSubscriptions: boolean = false): void {
+  disconnect(options?: DisconnectOptions | string): void {
+    let reason = 'Unknown reason';
+    let forgetSubscriptions = false;
+
+    /*
+     * To prevent breaking the legacy API, we allow options to be a string to represent
+     * the reason for the disconnect.
+     */
+    if (typeof options === 'string') {
+      reason = options;
+    } else if (options) {
+      forgetSubscriptions = options.forgetSubscriptions ?? forgetSubscriptions;
+      reason = options.reason ?? reason;
+    }
+
     if (forgetSubscriptions || !this._willAutoResubscribe) {
       this._subscriptions = {};
       this._subscriptions_cache = [];

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -571,8 +571,7 @@ export class WebSocketClient extends EventEmitter {
           if (undefined !== chan.product_ids) {
             // Remove product ids from the channel
             this._subscriptions[chan.name].product_ids = this._subscriptions[chan.name].product_ids.filter(x => {
-              /* istanbul ignore next: there should always be product_ids based on above typeguard */
-              return !chan.product_ids?.includes(x);
+              return !chan.product_ids!.includes(x);
             });
 
             // If no more products subscribed on the channel, delete its reference

--- a/src/client/WebSocketClient.ts
+++ b/src/client/WebSocketClient.ts
@@ -475,12 +475,12 @@ export class WebSocketClient extends EventEmitter {
       }
     };
 
-    this.socket.onopen = (): void => {
+    this.socket.onopen = async (): Promise<void> => {
       this.emit(WebSocketEvent.ON_OPEN);
 
       // Resubscribe if we had previous subscriptions
       if (this._willAutoResubscribe && this._subscriptions_cache.length > 0) {
-        this._subscribe(this._subscriptions_cache);
+        await this._subscribe(this._subscriptions_cache);
       }
 
       /**


### PR DESCRIPTION
@bennycode Here is a rough draft of #421. I've not written tests or even run the code yet. I just didn't want to go through full validation of it without getting your input on the architecture I've gone with. Could you take a look at what I have so far and give me any direction on changes you'd like to see?

In essence I've created a hashmap by channel name and keep the WebSocketChannel product IDs updated as subscribe and unsubscribe functions are called. If disconnect is called or the connection drops, the default behavior is to remember the previous subscriptions and re-subscribe to them when the connection comes back up. I added an optional parameter to the disconnect function to intentionally forget subscriptions if desired.